### PR TITLE
Feat: Allow specifying boot volume size

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ flowchart TD
 - `OPERATING_SYSTEM`: Exact name of the operating system 
 - `OS_VERSION`: Exact version of the operating system 
 - `ASSIGN_PUBLIC_IP`: Automatically assign an ephemeral public IP address
+- `BOOT_VOLUME_SIZE`: Size of boot volume in GB, values below 50 will be ignored and default to 50.
 - `NOTIFY_EMAIL`: Make it True if you want to get notified and provide email and password
 - `EMAIL`: Only Gmail is allowed, the same email will be used for *FROM* and *TO*
 - `EMAIL_PASSWORD`: If two-factor authentication is set, create an App Password and specify it, not the email password. Direct password will work if no two-factor authentication is configured for the email.

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ OCI_SUBNET_ID = os.getenv("OCI_SUBNET_ID", None).strip() if os.getenv("OCI_SUBNE
 OPERATING_SYSTEM = os.getenv("OPERATING_SYSTEM", "").strip()
 OS_VERSION = os.getenv("OS_VERSION", "").strip()
 ASSIGN_PUBLIC_IP = os.getenv("ASSIGN_PUBLIC_IP", "false").strip()
+BOOT_VOLUME_SIZE = os.getenv("BOOT_VOLUME_SIZE", "50").strip()
 NOTIFY_EMAIL = os.getenv("NOTIFY_EMAIL", 'False').strip().lower() == 'true'
 EMAIL = os.getenv("EMAIL", "").strip()
 EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD", "").strip()
@@ -417,6 +418,8 @@ def launch_instance():
 
     assign_public_ip = ASSIGN_PUBLIC_IP.lower() in [ "true", "1", "y", "yes" ]
 
+    boot_volume_size = max(50, int(BOOT_VOLUME_SIZE))
+
     ssh_public_key = read_or_generate_ssh_public_key(SSH_AUTHORIZED_KEYS_FILE)
 
     # Step 5 - Launch Instance if it's not already exist and running
@@ -441,7 +444,6 @@ def launch_instance():
                     ),
                     display_name=DISPLAY_NAME,
                     shape=OCI_COMPUTE_SHAPE,
-                    image_id=oci_image_id,
                     availability_config=oci.core.models.LaunchInstanceAvailabilityConfigDetails(
                         recovery_action="RESTORE_INSTANCE"
                     ),
@@ -449,6 +451,11 @@ def launch_instance():
                         are_legacy_imds_endpoints_disabled=False
                     ),
                     shape_config=shape_config,
+                    source_details=oci.core.models.InstanceSourceViaImageDetails(
+                        source_type="image",
+                        image_id=oci_image_id,
+                        boot_volume_size_in_gbs=boot_volume_size,
+                    ),
                     metadata={
                         "ssh_authorized_keys": ssh_public_key},
                 )

--- a/oci.env
+++ b/oci.env
@@ -11,9 +11,11 @@ SSH_AUTHORIZED_KEYS_FILE=/home/ubuntu/oracle-freetier-instance-creation/id_rsa.p
 OCI_SUBNET_ID=
 OCI_IMAGE_ID=
 # The following will be ignored if OCI_IMAGE_ID is specified
-OPERATING_SYSTEM=Canonical Ubuntu
+OPERATING_SYSTEM="Canonical Ubuntu"
 OS_VERSION=22.04
 ASSIGN_PUBLIC_IP=false
+# Boot volume size in GB (minimum is 50)
+BOOT_VOLUME_SIZE=50
 
 # Gmail Notification
 NOTIFY_EMAIL=False


### PR DESCRIPTION
Add `BOOT_VOLUME_SIZE` option to allow specifying size of boot volume to avoid having to resize later.