### PR TITLE
Feat: Add option to automatically request an ephemeral public IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ flowchart TD
 - `SECOND_MICRO_INSTANCE`: `True` if you are utilizing the script for your second free tier Micro Instance, else `False`.
 - `OPERATING_SYSTEM`: Exact name of the operating system 
 - `OS_VERSION`: Exact version of the operating system 
+- `ASSIGN_PUBLIC_IP`: Automatically assign an ephemeral public IP address
 - `NOTIFY_EMAIL`: Make it True if you want to get notified and provide email and password
 - `EMAIL`: Only Gmail is allowed, the same email will be used for *FROM* and *TO*
 - `EMAIL_PASSWORD`: If two-factor authentication is set, create an App Password and specify it, not the email password. Direct password will work if no two-factor authentication is configured for the email.

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ SECOND_MICRO_INSTANCE = os.getenv("SECOND_MICRO_INSTANCE", 'False').strip().lowe
 OCI_SUBNET_ID = os.getenv("OCI_SUBNET_ID", None).strip() if os.getenv("OCI_SUBNET_ID") else None
 OPERATING_SYSTEM = os.getenv("OPERATING_SYSTEM", "").strip()
 OS_VERSION = os.getenv("OS_VERSION", "").strip()
+ASSIGN_PUBLIC_IP = os.getenv("ASSIGN_PUBLIC_IP", "false").strip()
 NOTIFY_EMAIL = os.getenv("NOTIFY_EMAIL", 'False').strip().lower() == 'true'
 EMAIL = os.getenv("EMAIL", "").strip()
 EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD", "").strip()
@@ -414,6 +415,8 @@ def launch_instance():
     else:
         oci_image_id = OCI_IMAGE_ID
 
+    assign_public_ip = ASSIGN_PUBLIC_IP.lower() in [ "true", "1", "y", "yes" ]
+
     ssh_public_key = read_or_generate_ssh_public_key(SSH_AUTHORIZED_KEYS_FILE)
 
     # Step 5 - Launch Instance if it's not already exist and running
@@ -431,7 +434,7 @@ def launch_instance():
                     availability_domain=next(oci_ad_names),
                     compartment_id=oci_tenancy,
                     create_vnic_details=oci.core.models.CreateVnicDetails(
-                        assign_public_ip=False,
+                        assign_public_ip=assign_public_ip,
                         assign_private_dns_record=True,
                         display_name=DISPLAY_NAME,
                         subnet_id=oci_subnet_id,

--- a/oci.env
+++ b/oci.env
@@ -13,6 +13,7 @@ OCI_IMAGE_ID=
 # The following will be ignored if OCI_IMAGE_ID is specified
 OPERATING_SYSTEM=Canonical Ubuntu
 OS_VERSION=22.04
+ASSIGN_PUBLIC_IP=false
 
 # Gmail Notification
 NOTIFY_EMAIL=False


### PR DESCRIPTION
Add `ASSIGN_PUBLIC_IP` option (defaults to `false`) to avoid additional manual setup assigning a public IP to the instance.