### PR TITLE
Fix setup script startup on non-Linux hosts

### DIFF
--- a/main.py
+++ b/main.py
@@ -155,8 +155,11 @@ def list_all_instances(compartment_id):
     Returns:
         list: The list of instances returned from the OCI service.
     """
-    list_instances_response = compute_client.list_instances(compartment_id=compartment_id)
-    return list_instances_response.data
+    return execute_oci_command(
+        compute_client,
+        "list_instances",
+        compartment_id=compartment_id,
+    )
 
 
 def generate_html_body(instance):
@@ -277,17 +280,34 @@ def handle_errors(command, data, log):
     """
 
     # Check for temporary errors that can be retried
-    if "code" in data:
-        if (data["code"] in ("TooManyRequests", "Out of host capacity.", 'InternalError')) \
-                or (data["message"] in ("Out of host capacity.", "Bad Gateway")):
-            log.info("Command: %s--\nOutput: %s", command, data)
-            time.sleep(WAIT_TIME)
-            return True
+    retryable_codes = {
+        "TooManyRequests",
+        "Out of host capacity.",
+        "InternalError",
+        "RequestException",
+    }
+    retryable_statuses = {502, 503, 504}
+    retryable_messages = (
+        "Out of host capacity.",
+        "Bad Gateway",
+        "Max retries exceeded",
+        "ProxyError",
+        "Tunnel connection failed",
+        "Connection aborted",
+        "ConnectTimeout",
+        "Read timed out",
+    )
+    message = data.get("message", "")
 
-    if "status" in data and data["status"] == 502:
-        log.info("Command: %s~~\nOutput: %s", command, data)
+    if (
+        data.get("code") in retryable_codes
+        or data.get("status") in retryable_statuses
+        or any(retry_msg in message for retry_msg in retryable_messages)
+    ):
+        log.info("Command: %s--\nOutput: %s", command, data)
         time.sleep(WAIT_TIME)
         return True
+
     failure_msg = '\n'.join([f'{key}: {value}' for key, value in data.items()])
     notify_on_failure(failure_msg)
     # Raise an exception for unexpected errors
@@ -318,6 +338,13 @@ def execute_oci_command(client, method, *args, **kwargs):
             data = {"status": srv_err.status,
                     "code": srv_err.code,
                     "message": srv_err.message}
+            handle_errors(args, data, logging_step5)
+        except oci.exceptions.RequestException as req_err:
+            data = {
+                "status": None,
+                "code": "RequestException",
+                "message": str(req_err),
+            }
             handle_errors(args, data, logging_step5)
 
 
@@ -479,6 +506,13 @@ def launch_instance():
                 "status": srv_err.status,
                 "code": srv_err.code,
                 "message": srv_err.message,
+            }
+            handle_errors("launch_instance", data, logging_step5)
+        except oci.exceptions.RequestException as req_err:
+            data = {
+                "status": None,
+                "code": "RequestException",
+                "message": str(req_err),
             }
             handle_errors("launch_instance", data, logging_step5)
 

--- a/setup_init.sh
+++ b/setup_init.sh
@@ -10,9 +10,14 @@ fi
 # Making environment non-interactive
 export DEBIAN_FRONTEND=noninteractive
 
+is_debian_or_ubuntu() {
+    [ -f /etc/os-release ] && . /etc/os-release && \
+        { [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ] || [[ " $ID_LIKE " == *" debian "* ]]; }
+}
+
 # Check if the argument is 'rerun'
 if [ "$1" != "rerun" ]; then
-    if type apt >/dev/null 2>&1; then
+    if is_debian_or_ubuntu && command -v apt >/dev/null 2>&1; then
         # Update package lists and install required packages without confirmation
         sudo apt update -y
         sudo apt install python3-venv -y
@@ -53,8 +58,8 @@ send_notification() {
   fi
 }
 
-# Add this near the top of the script, after the send_notification function is defined
-trap 'send_notification "🛑 The setup_init.sh script has been terminated."' EXIT
+NORMAL_EXIT=0
+trap 'if [ "$NORMAL_EXIT" -ne 1 ]; then send_notification "🛑 The setup_init.sh script has been terminated."; fi' EXIT
 
 # Load environment variables
 source oci.env
@@ -77,8 +82,11 @@ handle_suspend() {
 trap cleanup SIGINT SIGTERM
 trap handle_suspend SIGTSTP
 
-# Run the Python program in the background
-nohup python3 main.py > /dev/null 2>&1 &
+PYTHON_ERROR_LOG="python_error.log"
+SCRIPT_FAILED=0
+
+# Run the Python program in the background. Keep stdout/stderr so crashes are diagnosable.
+python3 main.py > "$PYTHON_ERROR_LOG" 2>&1 < /dev/null &
 
 # Store the PID of the background process
 SCRIPT_PID=$!
@@ -109,6 +117,10 @@ else
     if [ -s "launch_instance.log" ]; then
         echo "Script is running successfully"
         send_notification "👍 Good news! The script is up and running after a short delay."
+    elif ! is_script_running; then
+        echo "Python process exited before launch_instance.log was written. Check $PYTHON_ERROR_LOG"
+        send_notification "😱 The OCI script exited before writing launch_instance.log. Check $PYTHON_ERROR_LOG."
+        SCRIPT_FAILED=1
     else
         echo "Unhandled Exception Occurred."
         send_notification "😱 Yikes! An unhandled exception occurred. Time to put on the detective hat!"
@@ -120,10 +132,16 @@ while is_script_running; do
     sleep 60
 done
 
-send_notification "🏁 The OCI Instance Creation Script has finished running."
+if [ "$SCRIPT_FAILED" -ne 1 ]; then
+    send_notification "🏁 The OCI Instance Creation Script has finished running."
+fi
 
 # Deactivate the virtual environment
 deactivate
 
 # Exit the script
+NORMAL_EXIT=1
+if [ "$SCRIPT_FAILED" -eq 1 ]; then
+    exit 1
+fi
 exit 0


### PR DESCRIPTION
  Changes:
  - Only run apt installation on Debian/Ubuntu-like systems.
  - Avoid nohup startup failures by launching the Python script with redirected stdin/stdout/stderr.
  - Preserve Python startup errors in python_error.log.
  - Avoid sending misleading finished/terminated notifications after startup failure.